### PR TITLE
Adds sidekiq web

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,3 +48,4 @@ gem 'json'
 gem 'sidekiq'
 gem 'redis'
 gem 'pry'
+gem 'sinatra', require: nil

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.3)
@@ -173,6 +175,10 @@ GEM
       json (~> 1.0)
       redis (~> 3.2, >= 3.2.1)
       redis-namespace (~> 1.5, >= 1.5.2)
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     slop (3.6.0)
     spring (1.4.0)
     sprockets (3.3.4)
@@ -216,8 +222,12 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   serialport
   sidekiq
+  sinatra
   spring
   sqlite3
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.10.5

--- a/app/assets/javascripts/data.json
+++ b/app/assets/javascripts/data.json
@@ -1,1 +1,0 @@
-{"state":"red_off"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,6 @@ Rails.application.routes.draw do
  put '/yellow_off', to: 'serial#yellow_off' 
  put '/red_on', to: 'serial#red_on'
  put '/red_off', to: 'serial#red_off'  
+ require 'sidekiq/web'
+ mount Sidekiq::Web => '/sidekiq'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,16 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+end


### PR DESCRIPTION
This adds a `/sidekiq` route where you can monitor workers and jobs, and see error logs for failing jobs

When I started the app, I say a worker failing with this error: `No such file or directory @ rb_sysopen - /home/naps62/creatorsschool/railsduino/app/assets/javascripts/test_worker.json`